### PR TITLE
chore: cannot release since empty github config

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,6 +57,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
       - uses: ./.github/actions/install-deps
 
       - name: Prepare repository


### PR DESCRIPTION
# What Changed

## Motivation

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[nexus--canary.12.4491648300.zip](https://github.com/homura/nexus/releases/download/v0.0.0-canary/nexus--canary.12.4491648300.zip)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
